### PR TITLE
Allow scanning a registry to fail

### DIFF
--- a/RegistryScanner/Project.toml
+++ b/RegistryScanner/Project.toml
@@ -1,6 +1,6 @@
 name = "RegistryScanner"
 uuid = "6972a089-c8e8-4e42-863e-263e67032df2"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"


### PR DESCRIPTION
This is just meant to handle random remote errors. #3 was caused by a GH outage.

Fixes #3